### PR TITLE
express deprecated req.host: Use req.hostname instead node_modules/conne...

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var connectLeg = module.exports = function connectLeg(log, toMerge) {
         request: {
           id: req._leg_requestId,
           method: req.method,
-          host: req.host,
+          host: req.hostname,
           path: req.url,
           origin: req.headers.origin,
           referer: req.headers.referer,
@@ -48,7 +48,7 @@ var connectLeg = module.exports = function connectLeg(log, toMerge) {
           request: {
             id: req._leg_requestId,
             method: req.method,
-            host: req.host,
+            host: req.hostname,
             path: req.url,
           },
           response: {


### PR DESCRIPTION
express deprecated req.host: Use req.hostname instead node_modules/connect-leg/index.js:27:20
express deprecated req.host: Use req.hostname instead node_modules/connect-leg/index.js:51:22
