### PR TITLE
Stop express complaining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+/test/*.log

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Usage
 app.use(require("connect-leg")(log));
 ```
 
+Test
+----
+
+```shell
+npm test
+```
+
 License
 -------
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var connectLeg = module.exports = function connectLeg(log, toMerge) {
         request: {
           id: req._leg_requestId,
           method: req.method,
-          host: req.host,
+          host: req.hostname || req.headers['host'],
           path: req.url,
           origin: req.headers.origin,
           referer: req.headers.referer,
@@ -48,7 +48,7 @@ var connectLeg = module.exports = function connectLeg(log, toMerge) {
           request: {
             id: req._leg_requestId,
             method: req.method,
-            host: req.host,
+            host: req.hostname || req.headers['host'],
             path: req.url,
           },
           response: {

--- a/package.json
+++ b/package.json
@@ -20,5 +20,16 @@
     "proquint-random-id": "~0.0.1",
     "deepmerge": "~0.2.7",
     "parstack": "0.0.1"
+  },
+  "devDependencies": {
+    "connect": "^3.3.5",
+    "express": "^4.12.3",
+    "leg": "^1.3.0-develop",
+    "mocha": "^2.2.4",
+    "request": "^2.55.0",
+    "should": "^6.0.1"
+  },
+  "scripts": {
+    "test": "node_modules/mocha/bin/mocha"
   }
 }

--- a/test/connect_test.js
+++ b/test/connect_test.js
@@ -1,0 +1,53 @@
+var LOG_FILE = 'test/connect_leg.log',
+	fs = require('fs'),
+	connect = require('connect'),
+	leg = require('leg')(LOG_FILE, { level: 'info' }),
+	logger = require('../index.js'),
+	request = require('request'),
+	should = require('should');
+
+describe('connect-leg for Connect', function() {
+	'use strict';
+
+	before(function(done) {
+		var app = connect();
+
+		app.use(logger(leg));
+
+		app.use(function(req, res, next) {
+			res.end('Hello World!');
+		});
+
+		app.listen(3001, function () {
+			done();
+		});
+	});
+
+	after(function(done) {
+		try {
+			fs.unlink(LOG_FILE, function(err) {
+				done();
+			});
+		}
+		catch(e) {
+			done();
+		}
+	});
+
+	it('Should be log a request', function(done) {
+		request('http://localhost:3001', function (err, response, body) {
+			(err === null).should.be.ok;
+			response.should.exist;
+
+			try {
+				fs.statSync(LOG_FILE).isFile().should.be.ok;
+				fs.readFileSync(LOG_FILE).toString().indexOf('localhost').should.be.greaterThan(-1);
+				done();
+			}
+			catch(e) {
+				(e === null).should.be.ok;
+				done();
+			}
+		});
+	});
+});

--- a/test/connect_test.js
+++ b/test/connect_test.js
@@ -34,7 +34,7 @@ describe('connect-leg for Connect', function() {
 		}
 	});
 
-	it('Should be log a request', function(done) {
+	it('Should be able to log a request', function(done) {
 		request('http://localhost:3001', function (err, response, body) {
 			(err === null).should.be.ok;
 			response.should.exist;

--- a/test/express_test.js
+++ b/test/express_test.js
@@ -34,7 +34,7 @@ describe('connect-leg for Express', function() {
 		}
 	});
 
-	it('Should be log a request', function(done) {
+	it('Should be able to log a request', function(done) {
 		request('http://localhost:3000', function (err, response, body) {
 			(err === null).should.be.ok;
 			response.should.exist;

--- a/test/express_test.js
+++ b/test/express_test.js
@@ -1,0 +1,53 @@
+var LOG_FILE = 'test/express_leg.log',
+	fs = require('fs'),
+	express = require('express'),
+	leg = require('leg')(LOG_FILE, { level: 'info' }),
+	logger = require('../index.js'),
+	request = require('request'),
+	should = require('should');
+
+describe('connect-leg for Express', function() {
+	'use strict';
+
+	before(function(done) {
+		var app = express();
+
+		app.use(logger(leg));
+
+		app.get('/', function(req, res) {
+		  res.send('Hello World!');
+		});
+
+		var server = app.listen(3000, function () {
+			done();
+		});
+	});
+
+	after(function(done) {
+		try {
+			fs.unlink(LOG_FILE, function(err) {
+				done();
+			});
+		}
+		catch(e) {
+			done();
+		}
+	});
+
+	it('Should be log a request', function(done) {
+		request('http://localhost:3000', function (err, response, body) {
+			(err === null).should.be.ok;
+			response.should.exist;
+
+			try {
+				fs.statSync(LOG_FILE).isFile().should.be.ok;
+				fs.readFileSync(LOG_FILE).toString().indexOf('localhost').should.be.greaterThan(-1);
+				done();
+			}
+			catch(e) {
+				(e === null).should.be.ok;
+				done();
+			}
+		});
+	});
+});


### PR DESCRIPTION
I've changed the way that the hostname is grabbed out of the request object. Express was showing a deprecated warning, and connect was not actually fetching the hostname. I've also added tests, and did a small update to the readme to explain how to run the tests.